### PR TITLE
removed the deprecated joy dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   rospy
   std_msgs
-  joy
   nav_msgs
   tf
 )
@@ -14,7 +13,6 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
   CATKIN_DEPENDS
     std_msgs
-    joy
     nav_msgs
     tf
 )

--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,6 @@
     <build_depend>roscpp</build_depend>
     <build_depend>rospy</build_depend>
     <build_depend>std_msgs</build_depend>
-    <build_depend>joy</build_depend>
     <build_depend>nav_msgs</build_depend>
     <build_depend>tf</build_depend>
 
@@ -28,7 +27,6 @@
     <exec_depend>std_msgs</exec_depend>
     <exec_depend>gazebo_ros</exec_depend>
     <exec_depend>gazebo_ros_pkgs</exec_depend>
-    <exec_depend>joy</exec_depend>
     <exec_depend>nav_msgs</exec_depend>
     <exec_depend>tf</exec_depend>
 


### PR DESCRIPTION
The joy package was needed to teleoperate the simulated robot using a joystick device. Our teleop nodes are now under the [robotont_demos](https://github.com/robotont/robotont_demos) repository, which makes joy dependency here obsolete. 